### PR TITLE
Fix documentation of `id` keys in ServerMember* and UserUpdate events

### DIFF
--- a/docs/websockets/events.md
+++ b/docs/websockets/events.md
@@ -289,7 +289,10 @@ Server member details updated.
 ```json
 {
     "type": "ServerMemberUpdate",
-    "id": "{server_id}",
+    "id": {
+        "server": "{server_id}",
+        "user": "{user_id}"
+    },
     "data": {..},
     "clear": "{field}"
 }
@@ -307,7 +310,7 @@ A user has joined the group.
 ```json
 {
     "type": "ServerMemberJoin",
-    "id": "{channel_id}",
+    "id": "{server_id}",
     "user": "{user_id}"
 }
 ```
@@ -319,7 +322,7 @@ A user has left the group.
 ```json
 {
     "type": "ServerMemberLeave",
-    "id": "{channel_id}",
+    "id": "{server_id}",
     "user": "{user_id}"
 }
 ```
@@ -361,7 +364,7 @@ User has been updated.
 ```json
 {
     "type": "UserUpdate",
-    "id": "{server_id}",
+    "id": "{user_id}",
     "data": {..},
     "clear": "{field}"
 }


### PR DESCRIPTION
Remade from https://gitlab.insrt.uk/revolt/documentation/developers/-/merge_requests/6