### PR TITLE
chore: add discussion link to contribution guide

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -27,6 +27,10 @@ These do not apply if you're just working on the web app, you'll probably be fin
 
 If you want to deploy Revolt in production, consider using [revolt/self-hosted](https://github.com/revoltchat/self-hosted) instead.
 
+## Read before continuing
+
+The current contribution guidelines are [here](https://github.com/revoltchat/revolt/discussions/282#discussion-3777997) - please make sure to read those and commit to these before starting to change any code.
+
 ## Prerequisites
 
 You need to have these tools installed and ready to go.


### PR DESCRIPTION
As there is a bit of confusion sometimes, add the link to the discussion, which contains some more information.

Ultimately we would want to integrate those bullet points into the documentation tho.