### PR TITLE
fix: invalid type of `user` in UserRelationship event

### DIFF
--- a/docs/stack/bonfire/events.md
+++ b/docs/stack/bonfire/events.md
@@ -416,11 +416,12 @@ Your relationship with another user has changed.
 {
     "type": "UserRelationship",
     "id": "{your_user_id}",
-    "user": "{other_user_id}",
+    "user": "{..}",
     "status": "{status}"
 }
 ```
 
+- `user` field contains a User object.
 - `status` field matches Relationship Status in API.
 
 ### EmojiCreate


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [ ] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects

Changes the documented type of `user` field in `UserRelationship` websocket event. This field was documented as string (user's ID) but is a User object actually.
