### PR TITLE
fix: rename rAuth to Authifier

### DIFF
--- a/docs/stack/bonfire/events.md
+++ b/docs/stack/bonfire/events.md
@@ -511,7 +511,7 @@ Emoji has been deleted.
 
 ### Auth
 
-Forwarded events from rAuth, currently only session deletion events are forwarded.
+Forwarded events from [Authifier](https://github.com/authifier/authifier), currently only session deletion events are forwarded.
 
 ```json
 {


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
